### PR TITLE
Add an IPC control surface for run control and session overrides

### DIFF
--- a/AutoFateGrind/Core/AfgConstants.cs
+++ b/AutoFateGrind/Core/AfgConstants.cs
@@ -13,6 +13,9 @@ internal static class AfgConstants
     // Chat/log tag prefixed to AFG's player-facing and diagnostic lines.
     public const string LogPrefix = "[AFG]";
 
+    // Outward IPC surface version; bump on any breaking endpoint change.
+    public const int IpcApiVersion = 1;
+
     // Game-imposed Bicolor Gemstone wallet cap.
     public const int BicolorCap = 1500;
     public const int FollowUpWaitMs = 15_000;

--- a/AutoFateGrind/Core/Game/Fates/FateBlacklist.cs
+++ b/AutoFateGrind/Core/Game/Fates/FateBlacklist.cs
@@ -1,3 +1,4 @@
+using AutoFateGrind.Core.Tasks;
 using clib.Utils;
 using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.Enums;
@@ -14,6 +15,7 @@ internal static class FateBlacklist
     public static bool Contains(Configuration cfg, PublicEvent f)
     {
         if (cfg.BlacklistedFateIds.Contains(f.Id)) return true;
+        if (RunContext.AvoidedFateIds.Contains(f.Id)) return true;
         if (cfg.BlacklistedTypeIds.TryGetValue((int)f.FateType, out var set) && set.Contains(f.Id)) return true;
         return false;
     }

--- a/AutoFateGrind/Core/Ipc/AutoFateIpcProvider.cs
+++ b/AutoFateGrind/Core/Ipc/AutoFateIpcProvider.cs
@@ -1,0 +1,70 @@
+using ECommons.DalamudServices;
+using ECommons.EzIpcManager;
+
+namespace AutoFateGrind.Core.Ipc;
+
+// Outward IPC control surface, registered by EzIPC under the plugin's internal name and torn down by
+// ECommonsMain.Dispose. Endpoints swallow exceptions so none crosses the IPC boundary.
+internal static class AutoFateIpcProvider
+{
+    public static void Register() => EzIPC.Init(typeof(AutoFateIpcProvider));
+
+    [EzIPC("Control.APIVersion")]
+    public static int ApiVersion() => AfgConstants.IpcApiVersion;
+
+    [EzIPC("Control.IsRunning")]
+    public static bool IsRunning()
+    {
+        try
+        {
+            return Plugin.Instance.Controller.Running;
+        }
+        catch (Exception ex)
+        {
+            Svc.Log.Warning(ex, $"{AfgConstants.LogPrefix} IPC IsRunning failed");
+            return false;
+        }
+    }
+
+    [EzIPC("Control.Start")]
+    public static bool Start()
+        => OnFramework(() => Plugin.Instance.Controller.IpcStart(), false, "Start");
+
+    [EzIPC("Control.StartWith")]
+    public static bool StartWith(List<uint>? zones, string? modeId, int? stopValue, int? gearsetIndex, List<uint>? avoidedFates)
+        => OnFramework(() => Plugin.Instance.Controller.IpcStartWith(zones, modeId, stopValue, gearsetIndex, avoidedFates), false, "StartWith");
+
+    [EzIPC("Control.Stop")]
+    public static void Stop()
+        => OnFramework(() => Plugin.Instance.Controller.IpcStop(), "Stop");
+
+    [EzIPC("Control.Toggle")]
+    public static bool Toggle()
+        => OnFramework(() => Plugin.Instance.Controller.IpcToggle(), false, "Toggle");
+
+    // Blocks for the result on the framework thread. Runs inline when already on it, so no deadlock.
+    private static T OnFramework<T>(Func<T> work, T fallback, string label)
+    {
+        try
+        {
+            return Svc.Framework.RunOnFrameworkThread(work).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Svc.Log.Warning(ex, $"{AfgConstants.LogPrefix} IPC {label} failed");
+            return fallback;
+        }
+    }
+
+    private static void OnFramework(Action work, string label)
+    {
+        try
+        {
+            Svc.Framework.RunOnFrameworkThread(work).GetAwaiter().GetResult();
+        }
+        catch (Exception ex)
+        {
+            Svc.Log.Warning(ex, $"{AfgConstants.LogPrefix} IPC {label} failed");
+        }
+    }
+}

--- a/AutoFateGrind/Core/Modes/BuiltInModes.cs
+++ b/AutoFateGrind/Core/Modes/BuiltInModes.cs
@@ -1,3 +1,4 @@
+using AutoFateGrind.Core.Tasks;
 using AutoFateGrind.Core.Trading;
 
 namespace AutoFateGrind.Core.Modes;
@@ -18,12 +19,12 @@ public sealed class MaxGemstonesMode : IFateGrindMode
     public string Id => ModeId;
     public string DisplayName => "Farm Gemstones";
     public string Description => "Stops when Bicolor Gemstones hit your target. Auto-trade resumes the grind.";
-    public bool IsComplete(ModeContext ctx) => GemstoneCatalog.CurrentWalletCount() >= Plugin.Cfg.TargetGemstoneCount;
+    public bool IsComplete(ModeContext ctx) => GemstoneCatalog.CurrentWalletCount() >= RunContext.TargetGemstoneCount;
 
     public string? GetRemainingDisplay(ModeContext ctx)
     {
         var have = GemstoneCatalog.CurrentWalletCount();
-        var target = Plugin.Cfg.TargetGemstoneCount;
+        var target = RunContext.TargetGemstoneCount;
         return have < target ? $"{have} / {target} gems" : null;
     }
 }
@@ -34,11 +35,11 @@ public sealed class TimeBoxedMode : IFateGrindMode
     public string Id => ModeId;
     public string DisplayName => "Farm for Time";
     public string Description => "Runs for a set number of minutes, then stops. Always finishes the FATE in progress first.";
-    public bool IsComplete(ModeContext ctx) => ctx.Elapsed >= TimeSpan.FromMinutes(Math.Max(1, Plugin.Cfg.TargetMinutes));
+    public bool IsComplete(ModeContext ctx) => ctx.Elapsed >= TimeSpan.FromMinutes(Math.Max(1, RunContext.TargetMinutes));
 
     public string? GetRemainingDisplay(ModeContext ctx)
     {
-        var remaining = TimeSpan.FromMinutes(Math.Max(1, Plugin.Cfg.TargetMinutes)) - ctx.Elapsed;
+        var remaining = TimeSpan.FromMinutes(Math.Max(1, RunContext.TargetMinutes)) - ctx.Elapsed;
         if (remaining <= TimeSpan.Zero) return null;
         return remaining.TotalHours >= 1
             ? $"{(int)remaining.TotalHours}h {remaining.Minutes:D2}m left"
@@ -52,11 +53,11 @@ public sealed class RunCountMode : IFateGrindMode
     public string Id => ModeId;
     public string DisplayName => "Run N FATEs";
     public string Description => "Stops after a fixed number of FATE completions across all selected zones.";
-    public bool IsComplete(ModeContext ctx) => ctx.CompletedCount >= Plugin.Cfg.TargetFateCount;
+    public bool IsComplete(ModeContext ctx) => ctx.CompletedCount >= RunContext.TargetFateCount;
 
     public string? GetRemainingDisplay(ModeContext ctx)
     {
-        var remaining = Math.Max(0, Plugin.Cfg.TargetFateCount - ctx.CompletedCount);
+        var remaining = Math.Max(0, RunContext.TargetFateCount - ctx.CompletedCount);
         return remaining > 0 ? $"{remaining} FATEs left" : null;
     }
 }

--- a/AutoFateGrind/Core/Tasks/AutoFate.Movement.cs
+++ b/AutoFateGrind/Core/Tasks/AutoFate.Movement.cs
@@ -397,18 +397,17 @@ public sealed partial class AutoFate
     }
 
     private bool StopConditionMet()
-        => Plugin.Cfg.ActiveMode.IsComplete(new ModeContext { CompletedCount = session.CompletedCount, Zones = zones, Elapsed = session.Elapsed });
+        => RunContext.ActiveMode.IsComplete(new ModeContext { CompletedCount = session.CompletedCount, Zones = zones, Elapsed = session.Elapsed });
 
     private bool AdvanceClassQueueIfCapHit()
     {
-        var cfg = Plugin.Cfg;
-        if (!cfg.ApplyClassOnStart) return false;
-        if (cfg.ClassQueue.Count == 0) return false;
+        if (!RunContext.ApplyClassOnStart) return false;
+        if (RunContext.ClassQueue.Count == 0) return false;
 
-        var idx = ClassSwitcher.FindActiveEntryIndex(cfg.ClassQueue);
+        var idx = ClassSwitcher.FindActiveEntryIndex(RunContext.ClassQueue);
         if (idx < 0)
         {
-            if (cfg.AfterClassQueueDone == AfterClassQueueDone.StopRun)
+            if (Plugin.Cfg.AfterClassQueueDone == AfterClassQueueDone.StopRun)
             {
                 Status = "Class queue done";
                 Diag("All queued classes hit their level caps, stopping run");
@@ -417,7 +416,7 @@ public sealed partial class AutoFate
             return false;
         }
 
-        var entry = cfg.ClassQueue[idx];
+        var entry = RunContext.ClassQueue[idx];
         var jobId = ClassSwitcher.JobIdForUserIndex(entry.GearsetIndex);
         var currentJob = Svc.Objects.LocalPlayer?.ClassJob.RowId ?? 0;
         if (jobId == 0 || jobId == currentJob) return false;

--- a/AutoFateGrind/Core/Tasks/AutoFateController.RunLifecycle.cs
+++ b/AutoFateGrind/Core/Tasks/AutoFateController.RunLifecycle.cs
@@ -11,20 +11,23 @@ internal sealed partial class AutoFateController
     {
         FinalizeRun(s);
         Phase = AutoPhase.Idle;
-        MaybeRunAfterAction(s);
+        // Overrides outlive the grind so the after-run action still reports the run's own goal. Guarded so
+        // a stale end cannot wipe a newer run's snapshot.
+        if (!MaybeRunAfterAction(s) && s == session) RunContext.End();
     }
 
     // After-action gates: s must be the live session and have ended via stop condition (not manual Stop or fault).
-    private void MaybeRunAfterAction(AutoFateSession? s)
+    // True when an action was dispatched, which hands it ownership of clearing the run overrides.
+    private bool MaybeRunAfterAction(AutoFateSession? s)
     {
-        if (s is null || s != session || !s.CompletedByStopCondition || s.AfterActionDispatched) return;
+        if (s is null || s != session || !s.CompletedByStopCondition || s.AfterActionDispatched) return false;
         s.AfterActionDispatched = true;
 
         var action = Plugin.Cfg.AfterRun;
         if (action == AfterRunAction.StayLoggedIn)
         {
             Diag("Run completed by stop condition; after-run action = StayLoggedIn (no-op).");
-            return;
+            return false;
         }
 
         Diag($"Run completed by stop condition; starting after-run action {action}.");
@@ -33,8 +36,10 @@ internal sealed partial class AutoFateController
         Svc.Automation.Start(task, OnCompleted: () =>
         {
             Diag($"After-run action {action} finished.");
+            RunContext.End();
             Phase = AutoPhase.Idle;
         });
+        return true;
     }
 
     // Writes a finished run to history exactly once. Idempotent (guarded by session.Recorded) so the many
@@ -61,7 +66,7 @@ internal sealed partial class AutoFateController
                 EndLevel = s.CurrentLevel,
                 JobId = s.JobId,
                 JobAbbr = s.JobAbbr,
-                ModeName = Plugin.Cfg.ActiveMode.DisplayName,
+                ModeName = RunContext.ActiveMode.DisplayName,
                 ZoneNames = activeZones.Select(z => z.Name).ToList(),
             };
             Plugin.Instance.History.Append(record);

--- a/AutoFateGrind/Core/Tasks/AutoFateController.cs
+++ b/AutoFateGrind/Core/Tasks/AutoFateController.cs
@@ -1,5 +1,6 @@
 using AutoFateGrind.Core.External;
 using AutoFateGrind.Core.Game.Player;
+using AutoFateGrind.Core.Modes;
 using AutoFateGrind.Core.Trading;
 using AutoFateGrind.Core.Zones;
 using clib.Services;
@@ -15,6 +16,7 @@ internal sealed partial class AutoFateController
     private AutoFateSession? session;
     private IReadOnlyList<ZoneInfo> activeZones = [];
     public AutoFateSession? SessionSnapshot => session;
+    public IReadOnlyList<ZoneInfo> ActiveZones => activeZones;
 
     private static readonly Random rng = new();
 
@@ -37,6 +39,8 @@ internal sealed partial class AutoFateController
         if (activeZones.Count == 0)
         {
             Diag("Start aborted: no zones selected.");
+            // Reachable from /afg toggle and IPC, which have no on-screen gate like the Start button does.
+            ECommons.DalamudServices.Svc.Chat.PrintError("[AFG] Cannot start: pick at least one zone first.");
             return;
         }
 
@@ -57,7 +61,7 @@ internal sealed partial class AutoFateController
         };
         s.CaptureStartExp();
         session = s;
-        Diag($"Run starting: {activeZones.Count} zone(s), mode {Plugin.Cfg.ActiveMode.DisplayName}, wallet {startWallet}g, threshold {Plugin.Cfg.TradeThreshold}g, trade-on-cap {(Plugin.Cfg.TradeOnCap ? "on" : "off")}.");
+        Diag($"Run starting: {activeZones.Count} zone(s), mode {RunContext.ActiveMode.DisplayName}, wallet {startWallet}g, threshold {Plugin.Cfg.TradeThreshold}g, trade-on-cap {(Plugin.Cfg.TradeOnCap ? "on" : "off")}.");
 
         ApplyStartingClass();
         StartFateGrind(0, s);
@@ -65,17 +69,16 @@ internal sealed partial class AutoFateController
 
     private static void ApplyStartingClass()
     {
-        var cfg = Plugin.Cfg;
-        if (!cfg.ApplyClassOnStart) return;
-        if (cfg.ClassQueue.Count == 0) return;
+        if (!RunContext.ApplyClassOnStart) return;
+        if (RunContext.ClassQueue.Count == 0) return;
 
-        var idx = ClassSwitcher.FindActiveEntryIndex(cfg.ClassQueue);
+        var idx = ClassSwitcher.FindActiveEntryIndex(RunContext.ClassQueue);
         if (idx < 0)
         {
             ECommons.DalamudServices.Svc.Chat.Print("[AFG] Class queue: every entry is at its level cap, staying on current class.");
             return;
         }
-        var entry = cfg.ClassQueue[idx];
+        var entry = RunContext.ClassQueue[idx];
         var label = $"gearset {entry.GearsetIndex} ({ClassSwitcher.JobNameForUserIndex(entry.GearsetIndex)})";
         if (ClassSwitcher.TryEquip(entry))
             ECommons.DalamudServices.Svc.Chat.Print($"[AFG] Switching to {label}.");
@@ -86,12 +89,128 @@ internal sealed partial class AutoFateController
     public void Stop()
     {
         var ending = session;
-        Svc.Automation.Stop();
-        FinalizeRun(ending);
-        session = null;
-        activeZones = [];
-        Phase = AutoPhase.Idle;
-        if (ending is not null) Diag("Stop requested; session cleared.");
+        try
+        {
+            Svc.Automation.Stop();
+        }
+        finally
+        {
+            // Clear run state even if cancellation threw, so a fault cannot leave the snapshot armed.
+            FinalizeRun(ending);
+            session = null;
+            activeZones = [];
+            RunContext.End();
+            Phase = AutoPhase.Idle;
+            if (ending is not null) Diag("Stop requested; session cleared.");
+        }
+    }
+
+    // Starts a run with per-run overrides. A null argument keeps the saved config for that category, and
+    // overrides are never persisted. Framework thread only. Returns true only if a run began.
+    public bool IpcStartWith(List<uint>? zones, string? modeId, int? stopValue, int? gearsetIndex, List<uint>? avoidedFates)
+    {
+        if (Running)
+        {
+            Diag("IPC start ignored: a run is already active.");
+            return false;
+        }
+
+        IFateGrindMode? overrideMode = null;
+        if (modeId is not null)
+        {
+            overrideMode = FateGrindModes.GetById(modeId);
+            if (overrideMode is null)
+            {
+                Diag($"IPC start aborted: unknown grind mode '{modeId}'.");
+                return false;
+            }
+        }
+
+        var snapshot = BuildSnapshot(overrideMode, modeId, stopValue, gearsetIndex, avoidedFates);
+        var startList = zones is null
+            ? ZoneSelection.ResolveStartList(Plugin.Cfg)
+            : ZoneSelection.Resolve(zones.Distinct());
+
+        RunContext.Begin(snapshot);
+        try
+        {
+            RunAll(startList);
+        }
+        catch
+        {
+            RunContext.End();
+            throw;
+        }
+
+        if (!Running)
+        {
+            RunContext.End();
+            return false;
+        }
+        return true;
+    }
+
+    public bool IpcStart() => IpcStartWith(null, null, null, null, null);
+
+    public void IpcStop() => Stop();
+
+    public bool IpcToggle()
+    {
+        if (Running)
+        {
+            Stop();
+            return false;
+        }
+        return IpcStart();
+    }
+
+    // Resolves the IPC arguments into a run snapshot. Reads live gearset state, so framework thread only.
+    private static RunSnapshot BuildSnapshot(IFateGrindMode? overrideMode, string? modeId, int? stopValue, int? gearsetIndex, List<uint>? avoidedFates)
+    {
+        // stopValue targets the effective mode, so a caller can retarget the saved mode without restating it.
+        var effectiveModeId = modeId ?? Plugin.Cfg.ActiveMode.Id;
+        int? gemTarget = null, fateTarget = null, minuteTarget = null;
+        if (stopValue is int value)
+        {
+            switch (effectiveModeId)
+            {
+                case MaxGemstonesMode.ModeId: gemTarget = Math.Clamp(value, 1, AfgConstants.BicolorCap); break;
+                case RunCountMode.ModeId: fateTarget = Math.Max(1, value); break;
+                case TimeBoxedMode.ModeId: minuteTarget = Math.Max(1, value); break;
+            }
+        }
+
+        bool? applyClass = null;
+        IReadOnlyList<ClassQueueEntry>? classQueue = null;
+        if (gearsetIndex is int requested)
+        {
+            var userIndex = requested is >= 1 and <= 100 ? (byte)requested : (byte)0;
+            var jobId = userIndex == 0 ? (byte)0 : ClassSwitcher.JobIdForUserIndex(userIndex);
+            if (jobId != 0 && ClassSwitcher.IsCombatJob(jobId))
+            {
+                applyClass = true;
+                classQueue = new List<ClassQueueEntry> { new() { GearsetIndex = userIndex, JobId = jobId, StopAtLevel = 0 } };
+            }
+            else
+            {
+                Diag($"IPC start: gearset {requested} is not a usable combat gearset; keeping the current class.");
+                applyClass = false;
+                classQueue = [];
+            }
+        }
+
+        var avoidIds = avoidedFates is { Count: > 0 } ? new HashSet<uint>(avoidedFates) : null;
+
+        return new RunSnapshot
+        {
+            Mode = overrideMode,
+            TargetGemstoneCount = gemTarget,
+            TargetFateCount = fateTarget,
+            TargetMinutes = minuteTarget,
+            ApplyClassOnStart = applyClass,
+            ClassQueue = classQueue,
+            AvoidFateIds = avoidIds,
+        };
     }
 
 }

--- a/AutoFateGrind/Core/Tasks/RunContext.cs
+++ b/AutoFateGrind/Core/Tasks/RunContext.cs
@@ -1,0 +1,38 @@
+using AutoFateGrind.Core.Modes;
+
+namespace AutoFateGrind.Core.Tasks;
+
+// Per-run overrides captured at run start. A null field means that category was not overridden.
+internal sealed record RunSnapshot
+{
+    public IFateGrindMode? Mode { get; init; }
+    public int? TargetGemstoneCount { get; init; }
+    public int? TargetFateCount { get; init; }
+    public int? TargetMinutes { get; init; }
+    public bool? ApplyClassOnStart { get; init; }
+    public IReadOnlyList<ClassQueueEntry>? ClassQueue { get; init; }
+    public IReadOnlySet<uint>? AvoidFateIds { get; init; }
+}
+
+// Effective settings for the categories IPC can override. Reads the active snapshot during a run and live
+// config otherwise. Mutated only on the framework thread, from the controller's start/stop.
+internal static class RunContext
+{
+    private static readonly HashSet<uint> noAvoid = [];
+
+    private static RunSnapshot? active;
+
+    public static void Begin(RunSnapshot snapshot) => active = snapshot;
+    public static void End() => active = null;
+
+    public static IFateGrindMode ActiveMode => active?.Mode ?? Plugin.Cfg.ActiveMode;
+    public static int TargetGemstoneCount => active?.TargetGemstoneCount ?? Plugin.Cfg.TargetGemstoneCount;
+    public static int TargetFateCount => active?.TargetFateCount ?? Plugin.Cfg.TargetFateCount;
+    public static int TargetMinutes => active?.TargetMinutes ?? Plugin.Cfg.TargetMinutes;
+
+    public static bool ApplyClassOnStart => active?.ApplyClassOnStart ?? Plugin.Cfg.ApplyClassOnStart;
+    public static IReadOnlyList<ClassQueueEntry> ClassQueue => active?.ClassQueue ?? Plugin.Cfg.ClassQueue;
+
+    // Extra ids the caller asked to skip. Additive only, so the saved blacklist is still read live.
+    public static IReadOnlySet<uint> AvoidedFateIds => active?.AvoidFateIds ?? noAvoid;
+}

--- a/AutoFateGrind/Core/Zones/ZoneSelection.cs
+++ b/AutoFateGrind/Core/Zones/ZoneSelection.cs
@@ -3,8 +3,12 @@ namespace AutoFateGrind.Core.Zones;
 internal static class ZoneSelection
 {
     public static IReadOnlyList<ZoneInfo> ResolveStartList(Configuration cfg)
+        => Resolve(cfg.SelectedZones);
+
+    // Maps territory ids to their ZoneInfo in listed order, dropping any id not in the FATE-zone registry.
+    public static IReadOnlyList<ZoneInfo> Resolve(IEnumerable<uint> territoryIds)
     {
         var byId = ZoneRegistry.Zones.ToDictionary(z => z.TerritoryId);
-        return cfg.SelectedZones.Where(byId.ContainsKey).Select(id => byId[id]).ToList();
+        return territoryIds.Where(byId.ContainsKey).Select(id => byId[id]).ToList();
     }
 }

--- a/AutoFateGrind/Plugin.cs
+++ b/AutoFateGrind/Plugin.cs
@@ -1,6 +1,7 @@
 using AutoFateGrind.Core;
 using AutoFateGrind.Core.Debug;
 using AutoFateGrind.Core.Game.Watchers;
+using AutoFateGrind.Core.Ipc;
 using AutoFateGrind.Core.Stats;
 using AutoFateGrind.Core.Tasks;
 using AutoFateGrind.Windows;
@@ -54,6 +55,7 @@ public sealed class Plugin : IDalamudPlugin
         Cfg = Configuration;
         History = new RunHistory();
         Controller = new AutoFateController();
+        AutoFateIpcProvider.Register();
         gmAlertWatcher = new GmAlertWatcher();
         partyInviteWatcher = new PartyInviteWatcher();
 
@@ -73,7 +75,7 @@ public sealed class Plugin : IDalamudPlugin
 
         CommandManager.AddHandler(AfgConstants.PrimaryCommand, new CommandInfo(OnCommand)
         {
-            HelpMessage = "Toggle the Auto FATE Grind window. /afg config | stats | deps | about | target (dump current target's BaseId)."
+            HelpMessage = "Toggle the Auto FATE Grind window. /afg toggle (start or stop the grind) | config | stats | deps | about | target (dump current target's BaseId)."
         });
         CommandManager.AddHandler(AfgConstants.AliasCommand, new CommandInfo(OnCommand)
         {
@@ -138,6 +140,8 @@ public sealed class Plugin : IDalamudPlugin
             ToggleHistoryUi();
         else if (trimmed.Equals("target", StringComparison.OrdinalIgnoreCase))
             TargetDumper.Dump();
+        else if (trimmed.Equals("toggle", StringComparison.OrdinalIgnoreCase))
+            Controller.IpcToggle();
         else
             ToggleMainUi();
     }

--- a/AutoFateGrind/Windows/Sections/GoalProgress.cs
+++ b/AutoFateGrind/Windows/Sections/GoalProgress.cs
@@ -10,16 +10,16 @@ internal static class GoalProgress
 {
     public readonly record struct Info(float? Fraction, string CenterBig, string CenterSmall, string Remaining, bool Endless);
 
-    public static Info Resolve(Configuration cfg, AutoFateSession? s)
+    public static Info Resolve(AutoFateSession? s)
     {
         var completed = s?.CompletedCount ?? 0;
 
-        switch (cfg.ActiveMode.Id)
+        switch (RunContext.ActiveMode.Id)
         {
             case MaxGemstonesMode.ModeId:
             {
                 var have = s?.GemstoneCurrent ?? GemstoneCatalog.CurrentWalletCount();
-                var target = Math.Max(1, cfg.TargetGemstoneCount);
+                var target = Math.Max(1, RunContext.TargetGemstoneCount);
                 var left = Math.Max(0, target - have);
                 return new Info(
                     Math.Clamp(have / (float)target, 0f, 1f),
@@ -28,7 +28,7 @@ internal static class GoalProgress
             }
             case RunCountMode.ModeId:
             {
-                var target = Math.Max(1, cfg.TargetFateCount);
+                var target = Math.Max(1, RunContext.TargetFateCount);
                 var left = Math.Max(0, target - completed);
                 return new Info(
                     Math.Clamp(completed / (float)target, 0f, 1f),
@@ -37,7 +37,7 @@ internal static class GoalProgress
             }
             case TimeBoxedMode.ModeId:
             {
-                var targetMin = Math.Max(1, cfg.TargetMinutes);
+                var targetMin = Math.Max(1, RunContext.TargetMinutes);
                 var elapsed = s?.Elapsed ?? TimeSpan.Zero;
                 var remaining = TimeSpan.FromMinutes(targetMin) - elapsed;
                 var rem = remaining > TimeSpan.Zero

--- a/AutoFateGrind/Windows/Sections/RunningPanel.cs
+++ b/AutoFateGrind/Windows/Sections/RunningPanel.cs
@@ -24,7 +24,7 @@ internal static class RunningPanel
         var (accent, accentSoft, label) = PhasePalette(controller, inFate);
 
         DrawHeaderStrip(accent, accentSoft);
-        DrawHeroCard(cfg, controller, fate, inFate, accent, accentSoft, label);
+        DrawHeroCard(controller, fate, inFate, accent, accentSoft, label);
 
         Styling.VSpace(3f);
         var s = controller.SessionSnapshot;
@@ -32,13 +32,13 @@ internal static class RunningPanel
         if (StopButton.Draw(stopSub)) controller.Stop();
 
         Styling.VSpace(7f);
-        DrawStatTiles(cfg, controller);
+        DrawStatTiles(controller);
 
         Styling.VSpace(5f);
         DrawQueue(cfg);
 
         Styling.VSpace(4f);
-        DrawFooter(cfg);
+        DrawFooter(controller);
     }
 
     private static void DrawHeaderStrip(Vector4 accent, Vector4 accentSoft)
@@ -64,7 +64,7 @@ internal static class RunningPanel
     }
 
     private static void DrawHeroCard(
-        Configuration cfg, AutoFateController controller, PublicEvent? fate, bool inFate,
+        AutoFateController controller, PublicEvent? fate, bool inFate,
         Vector4 accent, Vector4 accentSoft, string label)
     {
         var scale = ImGuiHelpers.GlobalScale;
@@ -82,7 +82,7 @@ internal static class RunningPanel
         dl.AddRectFilled(origin, end, ImGui.GetColorU32(bg), Styling.CardRounding);
         dl.AddRect(origin, end, ImGui.GetColorU32(border), Styling.CardRounding, ImDrawFlags.None, active ? 2f : 1f);
 
-        var info = GoalProgress.Resolve(cfg, controller.SessionSnapshot);
+        var info = GoalProgress.Resolve(controller.SessionSnapshot);
 
         var padX = 16f * scale;
         var ringRadius = height * 0.5f - 15f * scale;
@@ -200,7 +200,7 @@ internal static class RunningPanel
         };
     }
 
-    private static void DrawStatTiles(Configuration cfg, AutoFateController controller)
+    private static void DrawStatTiles(AutoFateController controller)
     {
         var s = controller.SessionSnapshot;
         var scale = ImGuiHelpers.GlobalScale;
@@ -214,7 +214,7 @@ internal static class RunningPanel
         var hours = s?.Elapsed.TotalHours ?? 0;
         var gph = hours > 0 ? gems / hours : 0;
 
-        var info = GoalProgress.Resolve(cfg, s);
+        var info = GoalProgress.Resolve(s);
         var elapsedVal = s is null ? "0m 00s" : Formatting.Elapsed(s.Elapsed);
         var elapsedSub = info.Endless ? "" : info.Remaining;
 
@@ -290,12 +290,13 @@ internal static class RunningPanel
         ImGui.Dummy(new Vector2(width, rowHeight));
     }
 
-    private static void DrawFooter(Configuration cfg)
+    private static void DrawFooter(AutoFateController controller)
     {
         var current = Svc.ClientState.TerritoryType;
         var zone = ZoneRegistry.Zones.FirstOrDefault(z => z.TerritoryId == current);
         var name = zone?.Name ?? "(somewhere else)";
-        var queued = cfg.SelectedZones.Count;
+        // Count the run's own rotation, which an IPC caller can set independently of the saved selection.
+        var queued = controller.ActiveZones.Count;
         using (ImRaii.PushColor(ImGuiCol.Text, Styling.TextMuted))
             ImGui.TextUnformatted($"{name}   ·   {queued} zone{(queued == 1 ? "" : "s")} in rotation");
     }

--- a/README.md
+++ b/README.md
@@ -63,10 +63,57 @@ The plugin needs a few helpers for movement and combat to be installed and loade
 |---|---|
 | `/afg` | Toggle the main window |
 | `/fategrind` | Alias for `/afg` |
+| `/afg toggle` | Start or stop the grind |
 | `/afg config` | Open settings |
 | `/afg deps` | Open dependencies window |
 | `/afg about` | Open credits / links |
 | `/afg target` | Log targeted NPC's BaseId (debug helper) |
+
+## Driving AFG over IPC
+
+Auto FATE Grind registers a small IPC control surface so other Dalamud plugins can start, stop, and configure a run. All endpoints live under the `AutoFateGrind.` prefix. Overrides you pass are **session-only**: they apply to a single run and are never written to the plugin's saved settings, so a crash or reload cannot change the user's configuration.
+
+| Endpoint | Signature | Purpose |
+|---|---|---|
+| `AutoFateGrind.Control.APIVersion` | `int()` | IPC version; check before calling anything else. |
+| `AutoFateGrind.Control.IsRunning` | `bool()` | True while a run is active. |
+| `AutoFateGrind.Control.Start` | `bool()` | Start a run using the user's saved settings. Returns true if a run began. |
+| `AutoFateGrind.Control.StartWith` | `bool(List<uint>, string, int?, int?, List<uint>)` | Start a run with per-run overrides. Returns true if a run began. |
+| `AutoFateGrind.Control.Stop` | `void()` | Stop the current run (no-op if idle). |
+| `AutoFateGrind.Control.Toggle` | `bool()` | Start if idle, stop if running. Returns the resulting running state. |
+
+`StartWith` takes the overrides as primitives, in order. Any argument may be null to keep the user's saved value for that category:
+
+- `zones`: `List<uint>` of TerritoryType RowIds to grind; unknown ids are ignored.
+- `modeId`: `string`, one of `maxgemstones`, `runcount`, `timeboxed`, `endless`. An unknown id rejects the start.
+- `stopValue`: `int?`, the target for the chosen mode (gemstones, FATE count, or minutes; ignored for `endless`).
+- `gearsetIndex`: `int?`, a 1-based gear set to play for the run. If the slot is empty or holds a non-combat job, the run keeps the current class instead of switching. Pass `null` to use the user's saved class queue.
+- `avoidedFates`: `List<uint>` of overworld FATE ids to skip. These are added to the user's existing avoid list, not replaced.
+
+Subscribe with raw Dalamud call gates (no ECommons dependency required). The generic types must match exactly, including the nullable `int?` parameters:
+
+```csharp
+// Compatibility check first (pi is your IDalamudPluginInterface).
+var apiVersion = pi.GetIpcSubscriber<int>("AutoFateGrind.Control.APIVersion");
+try { if (apiVersion.InvokeFunc() != 1) return; }
+catch (Dalamud.Plugin.Ipc.Exceptions.IpcNotReadyError) { return; } // AFG not loaded
+
+// Start a one-hour timed run in the user's saved zones, on gear set 3, avoiding two FATEs.
+var startWith = pi.GetIpcSubscriber<List<uint>, string, int?, int?, List<uint>, bool>(
+    "AutoFateGrind.Control.StartWith");
+bool started = startWith.InvokeFunc(null, "timeboxed", 60, 3, new List<uint> { 1831, 1832 });
+
+// Query, stop, toggle.
+bool running = pi.GetIpcSubscriber<bool>("AutoFateGrind.Control.IsRunning").InvokeFunc();
+pi.GetIpcSubscriber<object>("AutoFateGrind.Control.Stop").InvokeAction();
+bool nowRunning = pi.GetIpcSubscriber<bool>("AutoFateGrind.Control.Toggle").InvokeFunc();
+```
+
+Notes:
+
+- Only primitives, `string`, and `List<uint>` cross the boundary; AFG does not expose its own types.
+- `Stop` is a void action: subscribe as `GetIpcSubscriber<object>` and call `InvokeAction`.
+- Pass `null` for a category to keep the user's saved value. An empty `zones` list means "no zones" and does not start a run, so use `null`, not an empty list, to fall back to the saved zone selection.
 
 ## More from me
 


### PR DESCRIPTION
## What

Adds an outward IPC control surface so other Dalamud plugins can start, stop, toggle, and query an AFG
run, optionally with per-run overrides (zones, mode, stop target, gear set, extra avoided FATEs). Also adds
an `/afg toggle` command that drives the same path.

Overrides are session-only: they live in an in-memory snapshot for the duration of one run and are never
written to the saved configuration.

## Why

AFG is currently only drivable by hand through its window. Plugins that sequence activities (rotation
managers, scheduled-task plugins, multi-plugin "do X then Y" setups) have no way to hand control to AFG and
take it back. This exposes the minimum surface to do that without asking callers to mutate the user's saved
settings, which is what an external plugin would otherwise have to do.

The `/afg toggle` command falls out of the same code path and covers the common "bind start/stop to a
macro or key" request.

Both of those are start paths that, unlike the Start button, have no on-screen gate for "no zones
selected". `RunAll`'s no-zones abort previously only wrote to `/xllog`, so it now also prints to chat,
matching what the sibling missing-dependencies abort already did.

## How to test

Dependencies from `/afg deps` must be installed first.

**Plain behaviour (no IPC):** start and stop a run from the window as usual and confirm nothing changed.
All the `Plugin.Cfg` reads this PR routes through `RunContext` fall back to `Plugin.Cfg` when no run
snapshot is active, so the window path should be identical to before.

**IPC:** pick one Shared FATE zone in the window and set the mode to something recognisable (say Farm
Gemstones with a high target). Then from any plugin, or a scratch dev plugin, check the version gate and
start a run that overrides the mode and gear set but keeps your saved zone selection:

```csharp
var v = pi.GetIpcSubscriber<int>("AutoFateGrind.Control.APIVersion").InvokeFunc(); // 1

var startWith = pi.GetIpcSubscriber<List<uint>, string, int?, int?, List<uint>, bool>(
    "AutoFateGrind.Control.StartWith");

// null zones = use the saved selection. 5-minute timed run on gear set 3.
startWith.InvokeFunc(null, "timeboxed", 5, 3, null);
```

Confirm AFG switches to gear set 3, teleports, grinds for five minutes and stops, and that the panel shows
the timed goal rather than the saved gemstone goal for the whole run. Then confirm `/afg config` is
unchanged: mode, target, zone selection and class queue should all still be what they were before the call.

`AutoFateGrind.Control.Stop` mid-run, then Start from the window, and confirm the second run uses the saved
settings rather than the previous IPC overrides.

To exercise the zone override, pass a `List<uint>` of TerritoryType RowIds instead of `null` and confirm
the run rotates only through those.

**Command:** `/afg toggle` starts a run with saved settings, `/afg toggle` again stops it. With no zones
selected it now prints a reason to chat instead of failing silently.

Verified in-game in Living Memory (Dawntrail).

## Checklist

- [x] `dotnet build -c Release` passes
- [x] Verified in-game on at least one Shared FATE zone in the affected expansion
- [x] If this changes user-visible behavior, README is updated
- [x] If this touches the automation loop, relevant `[AutoFateGrind]` log lines make the sequence auditable
